### PR TITLE
feat: enhance start menu height calculation to fit 4 rows w/o scrollbar

### DIFF
--- a/src/startMenu/startMenuAppModel.js
+++ b/src/startMenu/startMenuAppModel.js
@@ -78,11 +78,17 @@ export function getRecommendedApps(settings, favorites, pinnedApps) {
     if (!settings.get_boolean('start-menu-recommended-apps'))
         return [];
 
-    const pinnedIds = new Set(pinnedApps.map(app => app.get_id()));
-    return Shell.AppUsage.get_default().get_most_used()
+    const pinnedIds = new Set(
+        pinnedApps.filter(Boolean).map(app => app.get_id())
+    );
+    const mostUsed = Shell.AppUsage.get_default().get_most_used() ?? [];
+    return mostUsed
         .filter(app => {
+            if (!app)
+                return false;
             const appId = app.get_id();
-            return appShouldShow(app) &&
+            return appId &&
+                appShouldShow(app) &&
                 !pinnedIds.has(appId) &&
                 !favorites.isFavorite(appId);
         })
@@ -94,14 +100,22 @@ export function groupAppsByCategory(apps) {
         ...APP_CATEGORIES.map(category => [category.id, []]),
         ['other', []],
     ]);
-    for (const app of apps)
+    for (const app of apps) {
+        if (!app)
+            continue;
         groupedApps.get(categoryForApp(app)).push(app);
+    }
     return groupedApps;
 }
 
 function categoryForApp(app) {
+    if (!app)
+        return 'other';
+    const appInfo = app.get_app_info?.();
+    if (!appInfo)
+        return 'other';
     const categories = new Set(
-        (app.get_app_info().get_categories() ?? '')
+        (appInfo.get_categories?.() ?? '')
             .split(';')
             .filter(Boolean)
     );
@@ -113,6 +127,8 @@ function categoryForApp(app) {
 }
 
 export function appShouldShow(app) {
-    const appInfo = app.get_app_info();
+    if (!app)
+        return false;
+    const appInfo = app.get_app_info?.();
     return appInfo ? appInfo.should_show() : false;
 }

--- a/src/startMenu/startMenuController.js
+++ b/src/startMenu/startMenuController.js
@@ -42,6 +42,16 @@ import {
 
 const GRID_COLUMNS = 6;
 const APP_TILE_WIDTH = 88;
+const START_MENU_MIN_HEIGHT = 420;
+const START_MENU_TASKBAR_MARGIN = 96;
+const START_MENU_HEIGHT_BUFFER = 6;
+// Fixed fallback for the Start menu height, used only when the adaptive
+// measurement cannot run (e.g. the menu is configured to open straight into
+// "All apps"). It was tuned empirically as 610 -> 620 -> 623: at 610 four
+// pinned rows always triggered a scrollbar, 620 fixed fonts whose tile labels
+// wrap to two lines, but Segoe UI and similar fonts whose labels stay on a
+// single line still needed 623.
+const START_MENU_FALLBACK_MAX_HEIGHT = 623;
 const PASSIVE_SEARCH_CLASS =
     'simple-taskbar-windows-start-search-passive';
 const BLUR_MY_SHELL_POPUP_CLASSES = [
@@ -112,6 +122,7 @@ export class StartMenuController {
         this._selectedAppCategory = 'all';
         this._menuWidth = 0;
         this._menuHeight = 0;
+        this._idealMenuHeight = 0;
         this._menu = new PopupMenu.PopupMenu(
             sourceActor,
             0.5,
@@ -748,7 +759,7 @@ export class StartMenuController {
     _ensurePinnedView() {
         const pinnedApps = this._settings.get_strv('start-menu-pinned-apps')
             .map(id => this._appSystem.lookup_app(id))
-            .filter(app => appShouldShow(app));
+            .filter(app => Boolean(app) && appShouldShow(app));
         const recommended = getRecommendedApps(
             this._settings,
             this._favorites,
@@ -1246,12 +1257,83 @@ export class StartMenuController {
         if (!monitor)
             return;
         const width = Math.min(640, Math.max(420, monitor.width - 32));
-        const height = Math.min(610, Math.max(420, monitor.height - 96));
+
+        let height = this._measureIdealMenuHeight(width);
+        if (!height)
+            height = this._idealMenuHeight || START_MENU_FALLBACK_MAX_HEIGHT;
+        height = Math.max(
+            START_MENU_MIN_HEIGHT,
+            Math.min(height, monitor.height - START_MENU_TASKBAR_MARGIN)
+        );
+
         if (width === this._menuWidth && height === this._menuHeight)
             return;
 
         this._menuWidth = width;
         this._menuHeight = height;
         this._root.set_style(`width: ${width}px; height: ${height}px;`);
+    }
+
+    // Menu height that lets the pinned app grid keep its natural size, so the
+    // rows never trigger a vertical scrollbar, regardless of the font metrics
+    // in use (Cantarell, Segoe UI, ...). Every component is measured through
+    // its real preferred size, which already includes the CSS padding, border
+    // and margins (Clutter adds margins to the preferred size), and the fonts
+    // are resolved first so the values match what the menu renders.
+    _measureIdealMenuHeight(forWidth) {
+        const footerActor = this._footerController?.actor;
+        if (this.isOpen || !this._root || !this._searchEntry ||
+            !this._header || !footerActor || !this._scrollView ||
+            !this._pinnedView)
+            return 0;
+        // The menu adapts to the pinned grid; when it is configured to open
+        // straight into "All apps" there is no fixed grid to measure, so the
+        // caller falls back to START_MENU_FALLBACK_MAX_HEIGHT.
+        if (this._settings.get_boolean('start-menu-open-all-apps'))
+            return 0;
+
+        try {
+            this._resolveThemeNodes(this._root);
+
+            // Force a real layout pass on the still-hidden menu tree so the
+            // CSS fonts and the metrics derived from them are applied to the
+            // widgets exactly as they would be after the first paint. Without
+            // this the very first open is measured with the default font and
+            // sized wrongly (it only becomes correct from the second open).
+            const [, primeHeight] = this._root.get_preferred_height(forWidth);
+            const primeBox = new Clutter.ActorBox({
+                x1: 0,
+                y1: 0,
+                x2: forWidth,
+                y2: primeHeight,
+            });
+            this._root.allocate(primeBox, Clutter.AllocationFlags.NONE);
+
+            const [, searchHeight] =
+                this._searchEntry.get_preferred_height(forWidth);
+            const [, headerHeight] =
+                this._header.get_preferred_height(forWidth);
+            const [, footerHeight] =
+                footerActor.get_preferred_height(forWidth);
+            const scrollNode = this._scrollView.get_theme_node();
+            const scrollPadding = scrollNode.get_padding(St.Side.TOP) +
+                scrollNode.get_padding(St.Side.BOTTOM);
+            const [, pinnedHeight] =
+                this._pinnedView.get_preferred_height(forWidth);
+
+            const height = Math.ceil(
+                searchHeight +
+                headerHeight +
+                footerHeight +
+                scrollPadding +
+                pinnedHeight +
+                START_MENU_HEIGHT_BUFFER
+            );
+            this._idealMenuHeight = height;
+            return height;
+        } catch (e) {
+            this._idealMenuHeight = 0;
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
This PR improves the height calculation of the Eleven-style Start Menu to adaptively measure the natural size of the pinned apps grid, ensuring 4 rows of pinned apps fit cleanly without triggering unnecessary vertical scrollbars across different system fonts (e.g. Cantarell, Segoe UI).
