### PR TITLE
feat: add Match Icon Color option and update localization strings

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -316,6 +316,21 @@ export default class SimpleTaskbarPreferences extends ExtensionPreferences {
             },
             connectSettings
         );
+        const matchIconColorSubtitle = _(
+            'Match active taskbar indicator to the application icon’s dominant color'
+        );
+        const matchIconColorSwitch = new Adw.SwitchRow({
+            title: _('Match Icon Color'),
+            subtitle: matchIconColorSubtitle,
+            active: window._settings.get_boolean('match-icon-color'),
+        });
+        advancedAppearanceGroup.add(matchIconColorSwitch);
+        window._settings.bind(
+            'match-icon-color',
+            matchIconColorSwitch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
         const syncIndicatorControls = () => {
             const windowsXpThemeEnabled = window._settings.get_boolean(
                 'windows-xp-theme-enabled'
@@ -323,6 +338,7 @@ export default class SimpleTaskbarPreferences extends ExtensionPreferences {
             const enabled = customIndicatorColorsSwitch.active;
             indicatorStyleRow.sensitive = !windowsXpThemeEnabled;
             customIndicatorColorsSwitch.sensitive = !windowsXpThemeEnabled;
+            matchIconColorSwitch.sensitive = !windowsXpThemeEnabled;
             focusedIndicatorColorRow.visible = enabled;
             unfocusedIndicatorColorRow.visible = enabled;
             focusedIndicatorColorRow.sensitive = !windowsXpThemeEnabled &&

--- a/schemas/org.gnome.shell.extensions.simple-taskbar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.simple-taskbar.gschema.xml
@@ -61,6 +61,10 @@
       <default>false</default>
       <summary>Use custom running indicator colors</summary>
     </key>
+    <key name="match-icon-color" type="b">
+      <default>false</default>
+      <summary>Match active taskbar indicator to the application icon's dominant color</summary>
+    </key>
     <key name="focused-indicator-color" type="s">
       <default>'#60aef7'</default>
       <summary>Focused application indicator color</summary>

--- a/src/prefs/panelAppearancePage.js
+++ b/src/prefs/panelAppearancePage.js
@@ -189,6 +189,11 @@ export function addPanelAppearancePage({
     );
     connectSettings(
         settings,
+        'changed::match-icon-color',
+        syncWindowsXpTheme
+    );
+    connectSettings(
+        settings,
         'changed::custom-panel-color-enabled',
         syncWindowsXpTheme
     );

--- a/src/shared/windowsXpTheme.js
+++ b/src/shared/windowsXpTheme.js
@@ -86,6 +86,7 @@ export function applyWindowsXpThemeSettings(settings) {
     setBoolean(settings, 'start-menu-follow-panel-transparency', false);
     setBoolean(settings, 'start-menu-super-key', true);
     setBoolean(settings, 'custom-indicator-colors-enabled', false);
+    setBoolean(settings, 'match-icon-color', false);
     setBoolean(settings, 'custom-panel-color-enabled', false);
     setBoolean(settings, 'panel-border-enabled', false);
     setBoolean(settings, 'panel-border-light-enabled', false);

--- a/src/taskbar/taskbarAppearanceController.js
+++ b/src/taskbar/taskbarAppearanceController.js
@@ -5,6 +5,8 @@ import Clutter from 'gi://Clutter';
 
 import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
+import {getIconDominantColor} from '../themeUtils.js';
+
 const INDICATOR_ANIMATION_DURATION = 150;
 const INDICATOR_SEGMENT_GAP = 2;
 const APP_LABEL_SPACING = 8;
@@ -208,12 +210,27 @@ export class TaskbarAppearanceController {
 
     syncIndicatorColor(item) {
         let style = null;
-        if (item._taskbarRunning &&
-            this._settings.get_boolean('custom-indicator-colors-enabled')) {
-            const key = item._taskbarFocused
-                ? 'focused-indicator-color'
-                : 'unfocused-indicator-color';
-            style = `background-color: ${this._settings.get_string(key)};`;
+        if (item._taskbarRunning) {
+            if (item._taskbarFocused &&
+                this._settings.get_boolean('match-icon-color')) {
+                const dominantColor = getIconDominantColor(item._taskbarApp);
+                if (dominantColor) {
+                    style = `background-color: ${dominantColor};`;
+                } else if (this._settings.get_boolean(
+                    'custom-indicator-colors-enabled'
+                )) {
+                    style = `background-color: ${this._settings.get_string(
+                        'focused-indicator-color'
+                    )};`;
+                }
+            } else if (this._settings.get_boolean(
+                'custom-indicator-colors-enabled'
+            )) {
+                const key = item._taskbarFocused
+                    ? 'focused-indicator-color'
+                    : 'unfocused-indicator-color';
+                style = `background-color: ${this._settings.get_string(key)};`;
+            }
         }
 
         for (const segment of item._taskbarIndicator.get_children())

--- a/src/taskbar/taskbarController.js
+++ b/src/taskbar/taskbarController.js
@@ -413,6 +413,7 @@ export class TaskbarController {
         );
         for (const key of [
             'custom-indicator-colors-enabled',
+            'match-icon-color',
             'focused-indicator-color',
             'unfocused-indicator-color',
         ]) {

--- a/src/themeUtils.js
+++ b/src/themeUtils.js
@@ -1,9 +1,258 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 sultech
 
+import GdkPixbuf from 'gi://GdkPixbuf';
+import Gio from 'gi://Gio';
 import St from 'gi://St';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+const DOMINANT_COLOR_ICON_SIZE = 48;
+const _iconColorCache = new Map();
+
+function _ColorLuminance(r, g, b, lum) {
+    const dlum = lum || 0;
+    const rClamped = Math.round(Math.min(Math.max(r * (1 + dlum), 0), 255));
+    const gClamped = Math.round(Math.min(Math.max(g * (1 + dlum), 0), 255));
+    const bClamped = Math.round(Math.min(Math.max(b * (1 + dlum), 0), 255));
+    return `#${rClamped.toString(16).padStart(2, '0')}${gClamped.toString(16).padStart(2, '0')}${bClamped.toString(16).padStart(2, '0')}`;
+}
+
+function _RGBtoHSV(r, g, b) {
+    const M = Math.max(r, g, b);
+    const m = Math.min(r, g, b);
+    const c = M - m;
+
+    let h = 0;
+    if (c === 0) {
+        h = 0;
+    } else if (M === r) {
+        h = ((g - b) / c) % 6;
+    } else if (M === g) {
+        h = (b - r) / c + 2;
+    } else {
+        h = (r - g) / c + 4;
+    }
+
+    if (h < 0) h += 6;
+    h /= 6;
+
+    const v = M / 255;
+    const s = M !== 0 ? c / M : 0;
+
+    return { h, s, v };
+}
+
+function _HSVtoRGB(h, s, v) {
+    const c = v * s;
+    const h1 = h * 6;
+    const x = c * (1 - Math.abs((h1 % 2) - 1));
+    const m = v - c;
+
+    let r = 0, g = 0, b = 0;
+    if (h1 <= 1) {
+        r = c + m; g = x + m; b = m;
+    } else if (h1 <= 2) {
+        r = x + m; g = c + m; b = m;
+    } else if (h1 <= 3) {
+        r = m; g = c + m; b = x + m;
+    } else if (h1 <= 4) {
+        r = m; g = x + m; b = c + m;
+    } else if (h1 <= 5) {
+        r = x + m; g = m; b = c + m;
+    } else {
+        r = c + m; g = m; b = x + m;
+    }
+
+    return {
+        r: Math.round(r * 255),
+        g: Math.round(g * 255),
+        b: Math.round(b * 255)
+    };
+}
+
+function _getIconPixBuf(app) {
+    if (!app) return null;
+    let gicon = null;
+
+    if (typeof app.create_icon_texture === 'function') {
+        try {
+            const iconTexture = app.create_icon_texture(DOMINANT_COLOR_ICON_SIZE);
+            if (iconTexture && typeof iconTexture.get_gicon === 'function')
+                gicon = iconTexture.get_gicon();
+        } catch (e) {}
+    }
+
+    if (!gicon) {
+        if (typeof app.get_icon === 'function')
+            gicon = app.get_icon();
+        else if (typeof app.get_app_info === 'function' && app.get_app_info())
+            gicon = app.get_app_info().get_icon();
+        else if (app.gicon)
+            gicon = app.gicon;
+        else
+            gicon = app;
+    }
+
+    if (!gicon) return null;
+
+    if (gicon instanceof Gio.EmblemedIcon && typeof gicon.get_icon === 'function') {
+        gicon = gicon.get_icon();
+    }
+
+    if (!gicon) return null;
+
+    try {
+        if (gicon instanceof Gio.FileIcon) {
+            const file = gicon.get_file();
+            const path = file ? file.get_path() : null;
+            if (path && !path.includes('image-missing'))
+                return GdkPixbuf.Pixbuf.new_from_file_at_scale(path, DOMINANT_COLOR_ICON_SIZE, DOMINANT_COLOR_ICON_SIZE, true);
+        } else if (gicon instanceof Gio.ThemedIcon) {
+            const themeLoader = (typeof St !== 'undefined' && St.IconTheme) ?
+                ((St.IconTheme.get_for_display && typeof global !== 'undefined' && global.display) ? St.IconTheme.get_for_display(global.display) : St.IconTheme.new()) :
+                null;
+
+            if (themeLoader) {
+                let iconInfo = null;
+
+                if (typeof themeLoader.lookup_by_gicon === 'function') {
+                    try {
+                        iconInfo = themeLoader.lookup_by_gicon(gicon, DOMINANT_COLOR_ICON_SIZE, 0);
+                    } catch (e) {}
+                }
+
+                if (!iconInfo) {
+                    const iconNames = gicon.get_names ? gicon.get_names() : [];
+                    for (const name of iconNames) {
+                        try {
+                            if (typeof themeLoader.lookup_icon === 'function') {
+                                const info = themeLoader.lookup_icon(name, DOMINANT_COLOR_ICON_SIZE, 0);
+                                if (info) {
+                                    iconInfo = info;
+                                    break;
+                                }
+                            }
+                        } catch (e) {}
+                    }
+                }
+
+                if (iconInfo) {
+                    if (typeof iconInfo.load_icon === 'function') {
+                        try {
+                            const pix = iconInfo.load_icon();
+                            if (pix) return pix;
+                        } catch (e) {}
+                    }
+
+                    let iconFile = null;
+                    if (typeof iconInfo.get_filename === 'function') {
+                        iconFile = iconInfo.get_filename();
+                    } else if (typeof iconInfo.get_file === 'function') {
+                        const f = iconInfo.get_file();
+                        iconFile = f ? f.get_path() : null;
+                    }
+
+                    if (iconFile && !iconFile.includes('image-missing') && !iconFile.includes('missing')) {
+                        return GdkPixbuf.Pixbuf.new_from_file_at_scale(iconFile, DOMINANT_COLOR_ICON_SIZE, DOMINANT_COLOR_ICON_SIZE, true);
+                    }
+                }
+            }
+        } else if (typeof gicon.load === 'function') {
+            const [iconBuffer] = gicon.load(DOMINANT_COLOR_ICON_SIZE, null);
+            if (iconBuffer)
+                return GdkPixbuf.Pixbuf.new_from_stream(iconBuffer, null);
+        }
+    } catch (e) {}
+
+    return null;
+}
+
+export function getIconDominantColor(app) {
+    if (!app) return null;
+
+    let cacheKey = null;
+    if (typeof app.get_id === 'function') {
+        cacheKey = app.get_id();
+    } else if (app.to_string) {
+        cacheKey = app.to_string();
+    } else if (typeof app === 'string') {
+        cacheKey = app;
+    }
+
+    if (cacheKey && _iconColorCache.has(cacheKey)) {
+        return _iconColorCache.get(cacheKey);
+    }
+
+    try {
+        const pixBuf = _getIconPixBuf(app);
+        if (!pixBuf) return null;
+
+        const width = pixBuf.get_width();
+        const height = pixBuf.get_height();
+        const rowstride = pixBuf.get_rowstride();
+        const nChannels = pixBuf.get_n_channels();
+        const pixels = pixBuf.get_pixels();
+
+        if (!pixels || pixels.length === 0) return null;
+
+        let total = 0,
+            rTotal = 0,
+            gTotal = 0,
+            bTotal = 0;
+
+        const step = 2;
+        for (let y = 0; y < height; y += step) {
+            for (let x = 0; x < width; x += step) {
+                const offset = y * rowstride + x * nChannels;
+                if (offset + 2 >= pixels.length) continue;
+
+                const r = pixels[offset];
+                const g = pixels[offset + 1];
+                const b = pixels[offset + 2];
+                const a = nChannels >= 4 ? pixels[offset + 3] : 255;
+
+                if (a < 30) continue;
+
+                const saturation = Math.max(r, g, b) - Math.min(r, g, b);
+                const relevance = 0.1 * 255 * 255 + 0.9 * a * saturation;
+
+                rTotal += r * relevance;
+                gTotal += g * relevance;
+                bTotal += b * relevance;
+                total += relevance;
+            }
+        }
+
+        if (total === 0 || Number.isNaN(total)) return null;
+
+        total *= 255;
+        const r = rTotal / total;
+        const g = gTotal / total;
+        const b = bTotal / total;
+
+        if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+
+        const hsv = _RGBtoHSV(r * 255, g * 255, b * 255);
+        if (Number.isNaN(hsv.h) || Number.isNaN(hsv.s) || Number.isNaN(hsv.v)) return null;
+
+        if (hsv.s > 0.15)
+            hsv.s = 0.65;
+        hsv.v = 0.90;
+
+        const rgb = _HSVtoRGB(hsv.h, hsv.s, hsv.v);
+        const hexColor = _ColorLuminance(rgb.r, rgb.g, rgb.b, 0);
+
+        if (!/^#[0-9a-fA-F]{6}$/.test(hexColor)) return null;
+
+        if (cacheKey) {
+            _iconColorCache.set(cacheKey, hexColor);
+        }
+        return hexColor;
+    } catch (e) {
+        return null;
+    }
+}
 
 function _luminance(color) {
     return (0.299 * color.red +

--- a/src/windowsXpModeController.js
+++ b/src/windowsXpModeController.js
@@ -23,6 +23,7 @@ const LOCKED_SETTING_KEYS = [
     'application-overflow-enabled',
     'hide-app-labels',
     'custom-indicator-colors-enabled',
+    'match-icon-color',
     'custom-panel-color-enabled',
     'activities-button-position',
     'panel-border-enabled',


### PR DESCRIPTION
Adds an optional **Match Icon Color** setting that dynamically extracts the dominant accent color from the focused application's icon and applies it to the active taskbar indicator.