### PR TITLE
add option to hide pinned applications on secondary monitors

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,7 @@ src/overflow/applicationOverflowItemController.js
 prefs.js
 src/prefs/aboutPage.js
 src/prefs/applicationIconsGroup.js
+src/prefs/pinnedApplicationBehaviorDialog.js
 src/prefs/dockAppearanceGroup.js
 src/prefs/dockBehaviorGroup.js
 src/prefs/locationsGroup.js

--- a/schemas/org.gnome.shell.extensions.simple-taskbar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.simple-taskbar.gschema.xml
@@ -681,6 +681,11 @@
       <default>false</default>
       <summary>Hide pinned taskbar applications while they are not running</summary>
     </key>
+    <key name="hide-pinned-secondary-monitors" type="b">
+      <default>false</default>
+      <summary>Hide pinned applications on secondary monitor taskbars</summary>
+      <description>Show pinned applications only on the primary monitor taskbar, while secondary monitors show running windows alone</description>
+    </key>
     <key name="use-pinned-apps-as-launchers" type="b">
       <default>false</default>
       <summary>Use pinned applications as separate launchers</summary>

--- a/src/prefs/pinnedApplicationBehaviorDialog.js
+++ b/src/prefs/pinnedApplicationBehaviorDialog.js
@@ -15,6 +15,7 @@ import {
 
 const PINNED_APPLICATION_BEHAVIOR_SETTINGS = [
     'hide-pinned-taskbar-apps',
+    'hide-pinned-secondary-monitors',
     'use-pinned-apps-as-launchers',
     'hide-unpinned-taskbar-apps',
 ];
@@ -65,6 +66,15 @@ class PinnedApplicationBehaviorOptionsDialog extends Adw.Window {
             ),
         });
         applicationsGroup.add(hidePinnedAppsSwitch);
+
+        const hidePinnedSecondarySwitch = createSwitchRow(settings, {
+            key: 'hide-pinned-secondary-monitors',
+            title: _('Hide Pinned Applications on Secondary Monitors'),
+            subtitle: _(
+                'Show pinned applications only on the primary monitor'
+            ),
+        });
+        applicationsGroup.add(hidePinnedSecondarySwitch);
 
         const hideUnpinnedAppsSwitch = createSwitchRow(settings, {
             key: 'hide-unpinned-taskbar-apps',

--- a/src/secondaryPanel/secondaryPanelController.js
+++ b/src/secondaryPanel/secondaryPanelController.js
@@ -102,6 +102,8 @@ export class SecondaryPanelController {
         this._settings = settings;
         this._extensionDir = extensionDir;
         this._monitor = monitor;
+        this._isSecondaryMonitor = Boolean(monitor) &&
+            monitor.index !== Main.layoutManager.primaryIndex;
         this._openPreferencesCallback = openPreferences;
         this._visiblePanelItemIds = visiblePanelItemIds;
         this._windowDodgeController = null;
@@ -146,6 +148,7 @@ export class SecondaryPanelController {
                 this._applicationOverflowController.sync();
             },
             locationScope: isDock ? 'dock' : 'taskbar',
+            isSecondary: this._isSecondaryMonitor,
             getPositionActor: () => this._panelBox,
             getHoverAnimationMonitor: () => this._monitor,
             getPanelInteractionController: () => this._interactionController,
@@ -565,6 +568,7 @@ export class SecondaryPanelController {
             'system-menu-visible',
             'clock-visible',
             'hide-pinned-taskbar-apps',
+            'hide-pinned-secondary-monitors',
             'hide-unpinned-taskbar-apps',
         ]) {
             this._settings.connectObject(`changed::${key}`, () => {

--- a/src/shared/taskbarDefaults.js
+++ b/src/shared/taskbarDefaults.js
@@ -75,6 +75,7 @@ export function applyDefaultTaskbarSettings(settings) {
     setInteger(settings, 'group-apps-label-max-width', 160);
     setBoolean(settings, 'group-apps-use-fixed-width', true);
     setBoolean(settings, 'hide-pinned-taskbar-apps', false);
+    setBoolean(settings, 'hide-pinned-secondary-monitors', false);
     setBoolean(settings, 'hide-unpinned-taskbar-apps', false);
     setString(
         settings,

--- a/src/taskbar/taskbarController.js
+++ b/src/taskbar/taskbarController.js
@@ -106,6 +106,7 @@ export class TaskbarController {
         isHoverAnimationBlocked,
         ignoreTaskbarLock = false,
         locationScope = 'taskbar',
+        isSecondary = false,
     }) {
         this._settings = settings;
         this._appSystem = appSystem;
@@ -129,6 +130,7 @@ export class TaskbarController {
         this._isHoverAnimationBlocked = isHoverAnimationBlocked;
         this._getPreviews = getPreviewController;
         this._ignoreTaskbarLock = ignoreTaskbarLock;
+        this._isSecondary = isSecondary;
         this._alignmentActor = null;
         this._signalHolder = new TransientSignalHolder();
         this._appSignals = new Map();
@@ -193,6 +195,7 @@ export class TaskbarController {
             favorites: this._favorites,
             getInterestingWindows: app => this._interestingWindows(app),
             getLocationEntries: () => this._locationController.getEntries(),
+            isSecondary: this._isSecondary,
         });
         this._appearanceController = new TaskbarAppearanceController({
             settings: this._settings,
@@ -220,6 +223,7 @@ export class TaskbarController {
             setSessionOrder: order => this._entryModel.setSessionOrder(order),
             ignoreTaskbarLock: this._ignoreTaskbarLock,
             usePinnedAppLaunchers: () => this._usePinnedAppLaunchers(),
+            hidePinned: () => this._entryModel.hidePinned(),
         });
         this._showDesktopController = new TaskbarShowDesktopController({
             settings: this._settings,
@@ -515,15 +519,20 @@ export class TaskbarController {
                 this._refreshWorkspaceIsolation();
             }, this._signalHolder);
         }
-        this._settings.connectObject(
-            'changed::hide-pinned-taskbar-apps',
-            () => {
-                this._entryModel.resetSessionOrder();
-                this._queueRedisplay();
-                this._syncDragEnabled(true);
-            },
-            this._signalHolder
-        );
+        for (const pinnedKey of [
+            'hide-pinned-taskbar-apps',
+            'hide-pinned-secondary-monitors',
+        ]) {
+            this._settings.connectObject(
+                `changed::${pinnedKey}`,
+                () => {
+                    this._entryModel.resetSessionOrder();
+                    this._queueRedisplay();
+                    this._syncDragEnabled(true);
+                },
+                this._signalHolder
+            );
+        }
         this._settings.connectObject(
             'changed::hide-unpinned-taskbar-apps',
             () => {
@@ -1814,7 +1823,7 @@ export class TaskbarController {
                 : this._settings.get_boolean('taskbar-locked'),
             this._combineMode(),
             this._usePinnedAppLaunchers(),
-            this._settings.get_boolean('hide-pinned-taskbar-apps'),
+            this._entryModel.hidePinned(),
         ].join(':');
         if (!force && configuration === this._dragEnabled)
             return false;

--- a/src/taskbar/taskbarDragController.js
+++ b/src/taskbar/taskbarDragController.js
@@ -30,8 +30,10 @@ export class TaskbarDragController {
         setSessionOrder,
         ignoreTaskbarLock = false,
         usePinnedAppLaunchers,
+        hidePinned,
     }) {
         this._settings = settings;
+        this._hidePinned = hidePinned;
         this._favorites = favorites;
         this._taskbarActor = taskbarActor;
         this._dropTarget = dropTarget;
@@ -686,7 +688,7 @@ export class TaskbarDragController {
             (this._ignoreTaskbarLock ||
                 !this._settings.get_boolean('taskbar-locked')) &&
             !this._settings.get_boolean('default-gnome-panel') &&
-            !this._settings.get_boolean('hide-pinned-taskbar-apps') &&
+            !this._hidePinned() &&
             global.settings.is_writable('favorite-apps') &&
             this._taskbarActor.visible
         );

--- a/src/taskbar/taskbarEntryModel.js
+++ b/src/taskbar/taskbarEntryModel.js
@@ -8,12 +8,14 @@ export class TaskbarEntryModel {
         favorites,
         getInterestingWindows,
         getLocationEntries,
+        isSecondary = false,
     }) {
         this._settings = settings;
         this._tracker = tracker;
         this._favorites = favorites;
         this._getInterestingWindows = getInterestingWindows;
         this._getLocationEntries = getLocationEntries;
+        this._isSecondary = isSecondary;
         this._sessionOrder = [];
     }
 
@@ -29,10 +31,18 @@ export class TaskbarEntryModel {
         this._sessionOrder = [];
     }
 
+    hidePinned() {
+        if (this._isSecondary &&
+            this._settings.get_boolean('hide-pinned-secondary-monitors'))
+            return true;
+
+        return this._settings.get_boolean('hide-pinned-taskbar-apps');
+    }
+
     isPersistentPinned(app) {
         const appId = app ? app.get_id() : null;
         return Boolean(appId) && this._favorites.isFavorite(appId) &&
-            !this._settings.get_boolean('hide-pinned-taskbar-apps');
+            !this.hidePinned();
     }
 
     usePinnedAppLaunchers() {
@@ -40,7 +50,7 @@ export class TaskbarEntryModel {
     }
 
     pinnedApps() {
-        if (this._settings.get_boolean('hide-pinned-taskbar-apps'))
+        if (this.hidePinned())
             return [];
 
         const apps = [];


### PR DESCRIPTION
## Hide pinned applications on secondary monitors

### Problem

`hide-pinned-taskbar-apps` is global, so on a multi-monitor setup pinned
applications are shown on every panel or on none of them.

A layout that is not currently reachable: pinned applications once, on the
primary monitor, while the panels on the other monitors list only the windows
running on them. Combined with `isolate-monitors` this gives one launcher area
plus a per-monitor window list, which is what Dash to Panel offers — but Dash to
Panel replaces the top GNOME panel, and Simple Taskbar does not, so the
combination is worth having here.

### Change

New boolean `hide-pinned-secondary-monitors` (default `false`, so nothing
changes for existing users).

- `TaskbarEntryModel` gains a single `hidePinned()` method. Both places that
  previously read the setting (`isPersistentPinned()` and `pinnedApps()`) now go
  through it.
- The model takes an `isSecondary` flag, passed down from
  `SecondaryPanelController` through `TaskbarController`.
- `TaskbarDragController` receives `hidePinned` as a callback instead of reading
  the global key, so the Start Menu drop target follows the same rule.
  `_syncDragEnabled()` keys off it too.
- New switch in the Pinned Application Behavior dialog.

### Note on the dock

`isSecondary` is derived from the monitor, not hardcoded:

```js
this._isSecondaryMonitor = Boolean(monitor) &&
    monitor.index !== Main.layoutManager.primaryIndex;
```

`DockPanelManager._rebuild()` builds a `SecondaryPanelController` for the
primary monitor as well when `dock-multi-monitor-panels` is enabled, so a fixed
`true` would have hidden pinned applications everywhere. Panels are rebuilt on
`monitors-changed`, so the flag cannot go stale.

`DockPanelSettings` does not remap the new key, so it falls through `?? key` and
the dock and the taskbar share one setting. That seemed right — it is one
user-facing choice, not two.

### Testing

Tested on a `dev.sh` session with a second monitor added, in Default GNOME Panel
mode with the dock at the bottom, `dock-multi-monitor-panels` and
`isolate-monitors` enabled:

- primary monitor dock keeps its pinned applications
- secondary monitor dock shows only the windows running on it
- moving a window between monitors moves its button
- toggling the new switch at runtime updates both panels without a restart
- dragging to reorder pinned applications on the primary monitor still works

### Translations

`src/prefs/pinnedApplicationBehaviorDialog.js` was missing from
`po/POTFILES.in`, so none of that dialog's strings were extractable — including
the ones already there. Added the file. I did not regenerate the template or the
`.po` files, since that touches every translation; happy to run `update-po.sh`
and add it to this PR if you prefer it in one go.
